### PR TITLE
Update defunct process in memory

### DIFF
--- a/expect.go
+++ b/expect.go
@@ -56,6 +56,8 @@ func Spawn(name string, args ...string) (*Expect, error) {
 	}
 	killer := func() {
 		cmd.Process.Kill()
+		// the process is killed, however keeps a defunct process in memory
+		go cmd.Process.Wait()
 	}
 	return Create(pty, killer), nil
 }


### PR DESCRIPTION
When you kill a process in unix, the process waits around until it can
signal to it's parent process that it has exited and why it did so.

cmd.Wait() will wait for the process to finish after you've killed it
and return details about why it finished.